### PR TITLE
#1 Fix source image so it's using ubuntu:18.04

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,3 +1,3 @@
-FROM ubuntu-18.04
+FROM ubuntu:18.04
 
 RUN echo 'This is just a test'


### PR DESCRIPTION
ubuntu-18.04 is not the format for a tagged release.  This should now pull from dockerhub correctly.

Note, ubuntu:18.04 is a ~64MB image.  With 1GB of space, we can store roughly 16 of these at once.