### PR TITLE
Add python3 and x86 support

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -7,10 +7,12 @@ ENV DOCKER_BASE_IMAGE ${base_image:-unspecified}
 # Install all our dependencies, then blow away our list.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-       gcc-arm-none-eabi \
-       libnewlib-arm-none-eabi \
-       make \
-       && \
+        gcc \
+        gcc-arm-none-eabi \
+        libnewlib-arm-none-eabi \
+        make \
+        python3.6 \
+        && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Expand toolchains to support building x86 sims and tests in parallel with arm code.