### PR TITLE
Upgrade to Ubuntu-20.04, arm-none-eabi 9.2.1, python3.8

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,10 +1,11 @@
 # Copyright Stryd, Inc. February 2020, All rights reserved.
-ARG base_image=ubuntu:18.04 
+ARG base_image=ubuntu:20.04 
 
 FROM ${base_image}
 ENV DOCKER_BASE_IMAGE ${base_image:-unspecified}
 
 # Install all our dependencies, then blow away our list.
+# apt-get has a stable CLI, but apt does not.  Prefer apt-get.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         gcc \
@@ -14,12 +15,12 @@ RUN apt-get update && \
         libnewlib-arm-none-eabi \
         libusb-1.0-0 \
         make \
-        python3.7 \
+        python3.8 \
         python3-pip \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    update-alternatives --install /usr/bin/python3 python /usr/bin/python3.7 1
+    update-alternatives --install /usr/bin/python3 python /usr/bin/python3.8 1
 
 # Setup our entrypoint
 COPY ./entrypoint.sh /opt/image/entrypoint


### PR DESCRIPTION
Port from Ubuntu-18 to Ubuntu-20.  The new LTS version of the OS brings with it 5 years of support, GCC 9.2.1, and python 3.8.
The combination improves the stability, generated code size, and unifies windows and linux development with a modern version of the GCC compiler.